### PR TITLE
"use_slave" decorator & context manager

### DIFF
--- a/multidb/pinning.py
+++ b/multidb/pinning.py
@@ -95,18 +95,11 @@ class UseMaster(object):
 use_master = UseMaster()
 
 
-class UseSlave(object):
+class UseSlave(UseMaster):
     """A contextmanager/decorator to use the slave database."""
     "Use this in cases where the usual behavior would be to pin to master,"
     "such as when the request method is POST, but you know you're not doing any writing."
     old = False
-
-    def __call__(self, func):
-        @wraps(func)
-        def decorator(*args, **kw):
-            with self:
-                return func(*args, **kw)
-        return decorator
 
     def __enter__(self):
         self.old = this_thread_is_pinned()

--- a/multidb/pinning.py
+++ b/multidb/pinning.py
@@ -6,7 +6,7 @@ from multidb.conf import settings
 
 __all__ = ['this_thread_is_pinned', 'pin_this_thread', 'unpin_this_thread',
            'use_master', 'db_write', 'set_db_write_for_this_thread',
-           'unset_db_write_for_this_thread',
+           'use_slave', 'unset_db_write_for_this_thread',
            'this_thread_has_db_write_set',
            'set_db_write_for_this_thread_if_needed']
 
@@ -109,12 +109,12 @@ class UseSlave(object):
         return decorator
 
     def __enter__(self):
-        self.old = this_thread_has_db_write_set()
-        unset_db_write_for_this_thread()
+        self.old = this_thread_is_pinned()
+        unpin_this_thread()
 
     def __exit__(self, type, value, tb):
         if self.old:
-            set_db_write_for_this_thread()
+            pin_this_thread()
 
 use_slave = UseSlave()
 


### PR DESCRIPTION
Create a new context manager / decorator: use_slave that mirrors the use_master context manager / decorator. This is needed to override the default behavior in cases where the behavior would be to pin to master (e.g., if request method is a POST) but the decorated method is known not to do db writes.
